### PR TITLE
Fix serialization of arrays

### DIFF
--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -107,6 +107,8 @@ export function toSerializableObject(
                 "Got an array with an undefined value and `undefinedMode` was set to 'ignore'. This is an edge case that is not allowed, as it is impossible to ignore items inside an array. You can try setting `undefinedMode` to 'preserve' or 'null'."
               );
             }
+          } else {
+            result.push(subResult);
           }
         }
         return result;


### PR DESCRIPTION
## Summary
- handle defined elements in `toSerializableObject` for arrays

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68486d4ecb0083299cf8ab683b6b0a3c