### PR TITLE
Fix threejs resize using throttle

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "style-props-html": "^0.0.6",
+    "lodash": "^4.17.21",
     "three": "^0.173.0",
     "troika-three-text": "^0.52.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Button, Div, H1, I, Input, Label, P } from "style-props-html";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js";
+import throttle from "lodash/throttle.js";
 
 import "@fontsource/fira-code/300.css";
 import "@fontsource/fira-code/400.css";
@@ -185,6 +186,30 @@ function App() {
       ) {
         current.removeChild(threeObjectsRef.current.renderer.domElement);
       }
+    };
+  }, []);
+
+  // Keep the renderer in sync with the viewer div size.
+  useEffect(() => {
+    const threeObjects = threeObjectsRef.current;
+    const viewer = viewerRef.current;
+    if (!threeObjects || !viewer) return;
+
+    const resizeViewport = throttle(() => {
+      const { width, height } = viewer.getBoundingClientRect();
+      threeObjects.renderer.setSize(width, height);
+      threeObjects.camera.aspect = width / height;
+      threeObjects.camera.updateProjectionMatrix();
+    }, 100, { trailing: true });
+
+    window.addEventListener("resize", resizeViewport);
+
+    // Call once in case the initial size is different.
+    resizeViewport();
+
+    return () => {
+      window.removeEventListener("resize", resizeViewport);
+      resizeViewport.cancel();
     };
   }, []);
 

--- a/src/types/lodash-throttle.d.ts
+++ b/src/types/lodash-throttle.d.ts
@@ -1,0 +1,4 @@
+declare module "lodash/throttle.js" {
+  import throttle from "lodash";
+  export default throttle;
+}


### PR DESCRIPTION
## Summary
- ensure lodash is a dependency
- use lodash throttle to resize the renderer on window resize
- declare type for lodash throttle import

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'serialization' types)*

------
https://chatgpt.com/codex/tasks/task_e_6848c3212fc08329bddc95d1e1999404