### PR TITLE
Add resizable editor panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "style-props-html": "^0.0.6",
     "lodash": "^4.17.21",
     "three": "^0.173.0",
-    "troika-three-text": "^0.52.3"
+    "troika-three-text": "^0.52.3",
+    "react-resizable-panels": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,11 @@ import { identifyParts, OpenSCADPart } from "./openscad-parsing";
 import { createLabeledAxis } from "./AxisVisualizer";
 import useFSAUnsupported from "./hooks/useFSAUnsupported";
 import { formatError } from "./utils/serialization";
+import {
+  PanelGroup,
+  Panel,
+  PanelResizeHandle,
+} from "react-resizable-panels";
 
 const MAX_MESSAGES = 200;
 
@@ -610,23 +615,26 @@ function App() {
     URL.revokeObjectURL(url);
   };
   return (
-    <Div
-      display="flex"
-      flexDirection="row"
-      alignItems="flex-start"
-      justifyContent="flex-start"
-      height="100%"
-    >
-      <Div height="100%" flex={1.3}>
-        <EditorTab agent={editorTabAgent} />
-      </Div>
-      <Div
-        height="100%"
-        flex={1}
-        display="grid"
-        gridTemplateRows="auto 1.5fr 1fr"
-        gridTemplateColumns="1fr"
+    <>
+      <PanelGroup
+        direction="horizontal"
+        style={{ width: "100%", height: "100%" }}
       >
+        <Panel
+          defaultSize={35}
+          minSize={20}
+          onResize={editorTabAgent.layoutEditor}
+        >
+          <EditorTab agent={editorTabAgent} />
+        </Panel>
+        <PanelResizeHandle />
+        <Panel>
+          <Div
+            height="100%"
+            display="grid"
+            gridTemplateRows="auto 1.5fr 1fr"
+            gridTemplateColumns="1fr"
+          >
         {/* Render Controls */}
         <Div display="flex" flexDirection="row" gap="8px" padding="8px">
           <Button
@@ -816,7 +824,9 @@ function App() {
         >
           {messages.join("\n") + "\n"}
         </Div>
-      </Div>
+        </Div>
+      </Panel>
+      </PanelGroup>
       <Div
         position="fixed"
         width="100vw"
@@ -843,7 +853,7 @@ function App() {
           <P textAlign="center">Please switch to a browser from after 2016.</P>
         </Div>
       </Div>
-    </Div>
+    </>
   );
 }
 

--- a/src/hooks/useEditorTabAgent.ts
+++ b/src/hooks/useEditorTabAgent.ts
@@ -53,6 +53,8 @@ export interface EditorTabAgent {
   openExistingFile: () => Promise<void>;
   saveCurrentFile: () => Promise<void>;
   closeFile: () => Promise<void>;
+  /** Force the Monaco editor to relayout */
+  layoutEditor: () => void;
 }
 
 const isMac = () => {
@@ -181,6 +183,12 @@ export default function useEditorTabAgent({
     await deleteStoredFileHandle();
   };
 
+  const layoutEditor = useCallback(() => {
+    if (editorRef.current) {
+      editorRef.current.layout();
+    }
+  }, []);
+
   const onCtrlS = useCallback(() => {
     const canSave= editorLoaded && dirty && (fileIsLoaded || isNewFile)
     if(canSave) {
@@ -230,5 +238,6 @@ export default function useEditorTabAgent({
     openExistingFile,
     saveCurrentFile,
     closeFile,
+    layoutEditor,
   };
 }


### PR DESCRIPTION
## Summary
- make code editor resizable using `react-resizable-panels`
- expose new `layoutEditor` helper in editor agent

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module 'react-resizable-panels')*


------
https://chatgpt.com/codex/tasks/task_e_6849d03a672483299476bb70bb77c172