### PR TITLE
Replace split pane lib with manual implementation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,14 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  {
+    ignores: [
+      'dist',
+      'public/openscad.wasm.js',
+      'src/openscad.fonts.js',
+      'src/openscad.mcad.js',
+    ],
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/components/EditorTab.tsx
+++ b/src/components/EditorTab.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { Editor } from "@monaco-editor/react";
-import { forwardRef, RefObject, useEffect, useState } from "react";
+import { forwardRef } from "react";
 import { Aside, Br, Button, Div, DivProps, H1, Span } from "style-props-html";
 import { EditorTabAgent } from "../hooks/useEditorTabAgent";
 import { useRegisterOpenSCADLanguage } from "../openscad-lang";
@@ -23,18 +23,6 @@ export default forwardRef<HTMLDivElement, EditorTabProps>(function EditorTab(
 ) {
   const showNoneSelectedDialog = !agent.fileIsLoaded && !agent.isNewFile;
   useRegisterOpenSCADLanguage();
-  const [widthPx, setWidthPx] = useState<number | null>(null);
-  useEffect(() => {
-    setInterval(() => {
-      const storedValue = sessionStorage.getItem("editorWidth");
-      if (storedValue !== null) {
-        const newValue = Number(storedValue);
-        if (newValue !== widthPx) {
-          setWidthPx(newValue);
-        }
-      }
-    }, 100);
-  }, [widthPx]);
 
   return (
     <Div
@@ -101,11 +89,7 @@ export default forwardRef<HTMLDivElement, EditorTabProps>(function EditorTab(
         )}
       </Div>
 
-      <Div
-        width={widthPx ? `${widthPx}px` : "100%"}
-        height="100%"
-        position="relative"
-      >
+      <Div width="100%" height="100%" position="relative">
         <Editor
           onMount={(editor) => {
             agent.storeEditor(editor);


### PR DESCRIPTION
## Summary
- implement a simple resizable split pane in `App.tsx`
- drop SplitPane dependency and store editor width in state
- simplify `EditorTab` width handling
- ignore generated JS assets in ESLint

## Testing
- `npm run lint`
- `npm run build` *(fails: Expected ';', '}' or <eof> in openscad.fonts.js)*

------
https://chatgpt.com/codex/tasks/task_e_68749318b010832988b8050b769d86c7