### PR TITLE
Switch to react-three-fiber viewer

### DIFF
--- a/src/components/ThreeViewer.tsx
+++ b/src/components/ThreeViewer.tsx
@@ -1,0 +1,65 @@
+import { Canvas, useThree, useFrame } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js';
+import { MutableRefObject, useEffect, useRef } from 'react';
+
+export interface ThreeHandles {
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  renderer: THREE.WebGLRenderer;
+  loader: STLLoader;
+  ambientLight: THREE.AmbientLight;
+  directionalLight: THREE.DirectionalLight;
+  partsGroup: THREE.Group;
+}
+
+function Scene({ handleRef, controlsRef }: { handleRef: MutableRefObject<ThreeHandles | null>; controlsRef: MutableRefObject<OrbitControls | null>; }) {
+  const { scene, camera, gl } = useThree();
+  const groupRef = useRef<THREE.Group>(null!);
+  const ambientRef = useRef<THREE.AmbientLight>(null!);
+  const dirRef = useRef<THREE.DirectionalLight>(null!);
+
+  useEffect(() => {
+    handleRef.current = {
+      scene,
+      camera: camera as THREE.PerspectiveCamera,
+      renderer: gl,
+      loader: new STLLoader(),
+      ambientLight: ambientRef.current,
+      directionalLight: dirRef.current,
+      partsGroup: groupRef.current,
+    };
+  }, [scene, camera, gl, handleRef]);
+
+  useFrame(() => {
+    dirRef.current.position.copy(camera.position);
+    if (controlsRef.current) {
+      dirRef.current.target.position.copy(controlsRef.current.target);
+      dirRef.current.target.updateMatrixWorld();
+    }
+  });
+
+  return (
+    <>
+      <ambientLight ref={ambientRef} intensity={0.25} />
+      <directionalLight ref={dirRef} intensity={1} />
+      <group ref={groupRef} name="partsGroup" />
+      <OrbitControls ref={controlsRef} enableDamping dampingFactor={0.05} />
+    </>
+  );
+}
+
+export default function ThreeViewer({ handleRef, controlsRef }: { handleRef: MutableRefObject<ThreeHandles | null>; controlsRef: MutableRefObject<OrbitControls | null>; }) {
+  return (
+    <Canvas
+      camera={{ position: [0, 0, 100], fov: 75 }}
+      style={{ width: '100%', height: '100%' }}
+      onCreated={({ scene }) => {
+        scene.background = new THREE.Color(0xaaaaaa);
+      }}
+    >
+      <Scene handleRef={handleRef} controlsRef={controlsRef} />
+    </Canvas>
+  );
+}


### PR DESCRIPTION
## Summary
- add a ThreeViewer component built with react-three-fiber
- hook ThreeViewer into the App and drop manual renderer management
- fix `ResizeSVGHelper` import case

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module '@react-three/fiber')*

------
https://chatgpt.com/codex/tasks/task_e_68829ff420988329bff05e934858bea9