### PR TITLE
Fix missing axes in react-three-fiber viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,12 +156,12 @@ export default function App() {
   const orbitControlsRef = useRef<OrbitControls | null>(null);
   const threeObjectsRef = useRef<ThreeHandles | null>(null);
   const axesAdded = useRef(false);
+  const [threeReady, setThreeReady] = useState(false);
 
 
   useEffect(() => {
-    const three = threeObjectsRef.current;
-    if (!three || axesAdded.current) return;
-    const { scene } = three;
+    if (!threeReady || axesAdded.current) return;
+    const { scene } = threeObjectsRef.current!;
 
     const addAxis = (
       dir: THREE.Vector3,
@@ -206,7 +206,7 @@ export default function App() {
     );
 
     axesAdded.current = true;
-  }, []);
+  }, [threeReady]);
 
   useEffect(() => {
     if (!renderedAtLeastOnce) return;
@@ -472,7 +472,11 @@ export default function App() {
               )}
             </Div>
             <Div background="#aaa" position="relative">
-              <ThreeViewer handleRef={threeObjectsRef} controlsRef={orbitControlsRef} />
+              <ThreeViewer
+                handleRef={threeObjectsRef}
+                controlsRef={orbitControlsRef}
+                onReady={() => setThreeReady(true)}
+              />
               <Div
                 position="absolute"
                 top={0}

--- a/src/components/ThreeViewer.tsx
+++ b/src/components/ThreeViewer.tsx
@@ -14,7 +14,7 @@ export interface ThreeHandles {
   partsGroup: THREE.Group;
 }
 
-function Scene({ handleRef, controlsRef }: { handleRef: MutableRefObject<ThreeHandles | null>; controlsRef: MutableRefObject<OrbitControls | null>; }) {
+function Scene({ handleRef, controlsRef, onReady }: { handleRef: MutableRefObject<ThreeHandles | null>; controlsRef: MutableRefObject<OrbitControls | null>; onReady?: () => void; }) {
   const { scene, camera, gl } = useThree();
   const groupRef = useRef<THREE.Group>(null!);
   const ambientRef = useRef<THREE.AmbientLight>(null!);
@@ -30,7 +30,8 @@ function Scene({ handleRef, controlsRef }: { handleRef: MutableRefObject<ThreeHa
       directionalLight: dirRef.current,
       partsGroup: groupRef.current,
     };
-  }, [scene, camera, gl, handleRef]);
+    onReady?.();
+  }, [scene, camera, gl, handleRef, onReady]);
 
   useFrame(() => {
     dirRef.current.position.copy(camera.position);
@@ -50,7 +51,7 @@ function Scene({ handleRef, controlsRef }: { handleRef: MutableRefObject<ThreeHa
   );
 }
 
-export default function ThreeViewer({ handleRef, controlsRef }: { handleRef: MutableRefObject<ThreeHandles | null>; controlsRef: MutableRefObject<OrbitControls | null>; }) {
+export default function ThreeViewer({ handleRef, controlsRef, onReady }: { handleRef: MutableRefObject<ThreeHandles | null>; controlsRef: MutableRefObject<OrbitControls | null>; onReady?: () => void; }) {
   return (
     <Canvas
       camera={{ position: [0, 0, 100], fov: 75 }}
@@ -59,7 +60,7 @@ export default function ThreeViewer({ handleRef, controlsRef }: { handleRef: Mut
         scene.background = new THREE.Color(0xaaaaaa);
       }}
     >
-      <Scene handleRef={handleRef} controlsRef={controlsRef} />
+      <Scene handleRef={handleRef} controlsRef={controlsRef} onReady={onReady} />
     </Canvas>
   );
 }


### PR DESCRIPTION
## Summary
- ensure ThreeViewer notifies when scene is ready via `onReady` callback
- add state-driven effect in App to create axes after viewer initialization

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a71de6548329a5f8cc6d32aa7612